### PR TITLE
Get single article

### DIFF
--- a/src/components/GetArticles.vue
+++ b/src/components/GetArticles.vue
@@ -17,7 +17,7 @@
           <v-card-text>{{ article.description }}</v-card-text>
 
           <v-card-actions>
-            <v-btn text color="deep-purple accent-4">Read</v-btn>
+            <v-btn text @click="loadAdrticle(article.slug)" color="deep-purple accent-4">Read</v-btn>
             <v-btn text color="deep-purple accent-4">Bookmark</v-btn>
             <v-spacer></v-spacer>
             <v-btn icon>
@@ -43,7 +43,11 @@ export default {
     this.fetchArticles();
   },
   methods: {
-    ...mapActions(["fetchArticles"])
+    ...mapActions(["fetchArticles"]),
+    loadAdrticle(slug) {
+      this.$router.push({ path: `/article/${slug}`})
+    }
+
   }
 };
 </script>

--- a/src/components/GetSingleArticle.vue
+++ b/src/components/GetSingleArticle.vue
@@ -1,0 +1,34 @@
+<template>
+  <div>
+    <h1>{{singleArticle.title}}</h1>
+    <h4>by {{singleArticle.author.username}}</h4>
+    <div class="body" v-html="singleArticle.body"></div>
+  </div>
+</template>
+
+<script>
+import { mapActions, mapGetters } from "vuex";
+export default {
+  name: "GetSingleArticle",
+  props: ["slug"],
+  computed: mapGetters(["singleArticle"]),
+  created() {
+    this.fetchSingleArticle(this.slug);
+  },
+  methods: {
+    ...mapActions(["fetchSingleArticle"])
+  }
+};
+</script>
+
+<style scoped>
+
+.body {
+    margin: 0px 120px;
+}
+h1, h4 {
+    display: flex;
+    justify-content: center;
+    margin: 20px 0px;
+}
+</style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,6 +1,7 @@
 import Vue from 'vue'
 import VueRouter from 'vue-router'
 import Home from '../views/Home.vue'
+import SingleArticle from '../views/SingleArticle.vue'
 
 Vue.use(VueRouter)
 
@@ -17,6 +18,10 @@ const routes = [
     // this generates a separate chunk (about.[hash].js) for this route
     // which is lazy-loaded when the route is visited.
     component: () => import(/* webpackChunkName: "about" */ '../views/About.vue')
+  },
+  {
+    path: '/article/:slug',
+    component: SingleArticle
   }
 ]
 

--- a/src/store/modules/fetchAllArticles.js
+++ b/src/store/modules/fetchAllArticles.js
@@ -1,11 +1,13 @@
 import axios from 'axios';
 
 const state = {
-    articles: {}
+    articles: {},
+    article: {}
 }
 
 const getters = {
-    allArticles:(state) => state.articles
+    allArticles:(state) => state.articles,
+    singleArticle:(state) => state.article
 };
 
 const actions = {
@@ -14,12 +16,20 @@ const actions = {
             'https://ah-backend-athena-staging.herokuapp.com/api/articles'
             );
         commit('GET_ALL_ARTICLES', res.data.articles);
+    },
+
+    async fetchSingleArticle({ commit }, slug) {
+        const res = await axios.get(
+            `https://ah-backend-athena-staging.herokuapp.com/api/articles/${slug}`
+            );
+        commit('GET_SINGLE_ARTICLE', res.data);
     }
 }
 
 
 const mutations = {
-    GET_ALL_ARTICLES:(state, articles) => (state.articles = articles)
+    GET_ALL_ARTICLES:(state, articles) => (state.articles = articles),
+    GET_SINGLE_ARTICLE:(state, article) => (state.article = article)
 }
 
 

--- a/src/views/SingleArticle.vue
+++ b/src/views/SingleArticle.vue
@@ -1,0 +1,26 @@
+<template>
+    <div>
+        <GetSingleArticle v-bind:slug="slug" />
+    </div>
+</template>
+
+<script>
+
+import GetSingleArticle from '../components/GetSingleArticle'
+export default {
+    name: 'SingleArticle',
+    components: {
+        GetSingleArticle
+    },
+    data () {
+        return {
+            slug: this.$route.params.slug
+        }
+    }
+
+}
+</script>
+
+<style scoped>
+
+</style>


### PR DESCRIPTION
#### What does this PR do?
- This PR adds the capability to retrieve data for a single article.

#### Description of Task to be completed?
- [x] Fetch data from Author's Haven backend which retrieves all articles.
#### How should this be manually tested?
- git checkout to the branch `ft-single-article-171376425`
- Run the app using the command `npm run serve`
- When the app loads in the browser, Click on **READ MORE** option on a card.

#### What are the relevant pivotal tracker stories?
[#171376425](https://www.pivotaltracker.com/story/show/171376425)